### PR TITLE
ASU-X: Create taxonomy terms automatically

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -7,6 +7,7 @@ module:
   asu_apartment_search: 0
   asu_api: 0
   asu_application: 0
+  asu_content: 0
   asu_mailer: 0
   asu_rest: 0
   asu_user: 0

--- a/conf/cmi/views.view.news.yml
+++ b/conf/cmi/views.view.news.yml
@@ -8,9 +8,9 @@ dependencies:
     - node.type.news
     - taxonomy.vocabulary.news_category
   content:
-    - 'taxonomy_term:news_category:a288e575-4bdb-49a9-acd0-2b8139c3796b'
-    - 'taxonomy_term:news_category:e00bfdaa-ad8c-4e8e-a245-9857aa377b8d'
-    - 'taxonomy_term:news_category:f129e3de-c0d4-47db-ab60-ce11e9d5ed1a'
+    - 'taxonomy_term:news_category:72d1416b-cf66-4820-b4cd-060098c18d6f'
+    - 'taxonomy_term:news_category:a4cd9585-84aa-4a1b-ae53-6976cc08f4a4'
+    - 'taxonomy_term:news_category:daab6bb3-6810-456f-9922-1e70878024eb'
   module:
     - node
     - taxonomy

--- a/public/modules/custom/asu_content/asu_content.info.yml
+++ b/public/modules/custom/asu_content/asu_content.info.yml
@@ -1,0 +1,6 @@
+name: 'ASU - Content'
+type: module
+description: 'Logic related to ASU content'
+core: 8.x
+core_version_requirement: ^8 || ^9
+package: 'ASU'

--- a/public/modules/custom/asu_content/asu_content.install
+++ b/public/modules/custom/asu_content/asu_content.install
@@ -1,0 +1,32 @@
+<?php
+
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Add taxonomy terms to News category vocabularity automatically.
+ */
+function asu_content_update_8003() {
+  $vocabularity = 'news_category';
+
+  $term_common = Term::create([
+    'name' => 'Common',
+    'vid' => $vocabularity,
+    'uuid' => 'a4cd9585-84aa-4a1b-ae53-6976cc08f4a4'
+  ]);
+
+  $term_haso = Term::create([
+    'name' => 'HASO',
+    'vid' => $vocabularity,
+    'uuid' => '72d1416b-cf66-4820-b4cd-060098c18d6f'
+  ]);
+
+  $term_hitas = Term::create([
+    'name' => 'HITAS',
+    'vid' => $vocabularity,
+    'uuid' => 'daab6bb3-6810-456f-9922-1e70878024eb'
+  ]);
+
+  $term_common->save();
+  $term_haso->save();
+  $term_hitas->save();
+}

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -5,9 +5,9 @@
  * Functions to support theming in the HDBT Subtheme.
  */
 
-use Drupal\asu_application\Applications;
 use Drupal\Core\Url;
 use Drupal\paragraphs\Entity\Paragraph;
+use Drupal\asu_application\Applications;
 
 /**
  * Helper function to get the icons path.


### PR DESCRIPTION
This PR makes sure that everytime a new instance of this repo is built, it gets the same news_category taxonomy terms and doesn't brick itself.