### PR TITLE
ASU-X: FIX - Update fields to be plain texts instead of list strings

### DIFF
--- a/conf/cmi/core.entity_form_display.apartment.apartment.default.yml
+++ b/conf/cmi/core.entity_form_display.apartment.apartment.default.yml
@@ -109,10 +109,12 @@ content:
     type: string_textfield
     region: content
   field_attachments:
-    weight: 23
-    settings: {  }
+    weight: 25
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: string_textfield
     region: content
   field_building_type:
     weight: 8
@@ -215,16 +217,20 @@ content:
     type: number
     region: content
   field_services:
-    weight: 19
-    settings: {  }
+    weight: 23
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: string_textfield
     region: content
   field_services_url:
     weight: 24
-    settings: {  }
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: string_textfield
     region: content
   field_site_owner:
     weight: -2

--- a/conf/cmi/core.entity_form_display.project.project.default.yml
+++ b/conf/cmi/core.entity_form_display.project.project.default.yml
@@ -71,10 +71,12 @@ content:
     type: string_textfield
     region: content
   field_apartments:
-    weight: 22
-    settings: {  }
+    weight: 25
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: string_textfield
     region: content
   field_apartments_count:
     weight: -2
@@ -100,10 +102,12 @@ content:
     type: string_textfield
     region: content
   field_attachments:
-    weight: 23
-    settings: {  }
+    weight: 26
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: string_textfield
     region: content
   field_building_type:
     weight: 15
@@ -209,16 +213,20 @@ content:
     type: string_textfield
     region: content
   field_services:
-    weight: 13
-    settings: {  }
+    weight: 27
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: string_textfield
     region: content
   field_services_url:
-    weight: 24
-    settings: {  }
+    weight: 28
+    settings:
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: string_textfield
     region: content
   field_site_owner:
     weight: 17

--- a/conf/cmi/core.entity_view_display.apartment.apartment.default.yml
+++ b/conf/cmi/core.entity_view_display.apartment.apartment.default.yml
@@ -33,7 +33,6 @@ dependencies:
   module:
     - external_entities
     - imagecache_external
-    - options
 id: apartment.apartment.default
 targetEntityType: apartment
 bundle: apartment
@@ -116,11 +115,12 @@ content:
     type: string
     region: content
   field_attachments:
-    weight: 27
-    label: hidden
-    settings: {  }
+    weight: 29
+    label: above
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: list_default
+    type: string
     region: content
   field_building_type:
     weight: 12
@@ -239,18 +239,20 @@ content:
     type: number_decimal
     region: content
   field_services:
-    type: list_default
-    weight: 25
-    region: content
-    label: hidden
-    settings: {  }
+    weight: 27
+    label: above
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
+    type: string
+    region: content
   field_services_url:
     weight: 28
-    label: hidden
-    settings: {  }
+    label: above
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: list_default
+    type: string
     region: content
   field_site_owner:
     weight: 2

--- a/conf/cmi/core.entity_view_display.project.project.default.yml
+++ b/conf/cmi/core.entity_view_display.project.project.default.yml
@@ -33,7 +33,6 @@ dependencies:
   module:
     - external_entities
     - imagecache_external
-    - options
 id: project.project.default
 targetEntityType: project
 bundle: project
@@ -72,11 +71,12 @@ content:
     type: string
     region: content
   field_apartments:
-    weight: 27
+    weight: 30
     label: above
-    settings: {  }
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: list_default
+    type: string
     region: content
   field_apartments_count:
     weight: 3
@@ -104,11 +104,12 @@ content:
     type: string
     region: content
   field_attachments:
-    weight: 28
+    weight: 31
     label: above
-    settings: {  }
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: list_default
+    type: string
     region: content
   field_building_type:
     weight: 20
@@ -218,18 +219,20 @@ content:
     type: string
     region: content
   field_services:
-    weight: 18
-    label: hidden
-    settings: {  }
+    weight: 32
+    label: above
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: list_default
+    type: string
     region: content
   field_services_url:
-    weight: 29
+    weight: 33
     label: above
-    settings: {  }
+    settings:
+      link_to_entity: false
     third_party_settings: {  }
-    type: list_default
+    type: string
     region: content
   field_site_owner:
     weight: 22

--- a/conf/cmi/external_entities.external_entity_type.apartment.yml
+++ b/conf/cmi/external_entities.external_entity_type.apartment.yml
@@ -33,7 +33,7 @@ field_mappings:
   field_application_url:
     value: application_url
   field_attachments:
-    value: attachments
+    value: 'attachments/*'
   field_building_type:
     value: building_type
   field_cta_image:
@@ -70,7 +70,7 @@ field_mappings:
     value: site_renter
 storage_client_id: rest
 storage_client_config:
-  endpoint: 'http://Asu:asunnot_2020@dev.asuntotuotanto.druidfi.wod.by/fi/content/apartment'
+  endpoint: 'https://nginx-asuntotuotanto-test.agw.arodevtest.hel.fi/fi/content/apartment'
   response_format: json
   pager:
     default_limit: '50'

--- a/conf/cmi/external_entities.external_entity_type.project.yml
+++ b/conf/cmi/external_entities.external_entity_type.project.yml
@@ -31,7 +31,7 @@ field_mappings:
   field_application_start_time:
     value: application_start_time
   field_attachments:
-    value: attachments
+    value: 'attachments/*'
   field_building_type:
     value: field_building_type
   field_city:
@@ -70,7 +70,7 @@ field_mappings:
     value: field_street_address
 storage_client_id: rest
 storage_client_config:
-  endpoint: 'http://Asu:asunnot_2020@dev.asuntotuotanto.druidfi.wod.by/fi/content/project'
+  endpoint: 'https://nginx-asuntotuotanto-test.agw.arodevtest.hel.fi/fi/content/project'
   response_format: json
   pager:
     default_limit: '50'

--- a/conf/cmi/field.field.apartment.apartment.field_attachments.yml
+++ b/conf/cmi/field.field.apartment.apartment.field_attachments.yml
@@ -1,4 +1,4 @@
-uuid: ce2c1305-6043-4274-9cd6-f7274f5ec95c
+uuid: cf4ac86a-9fa9-40b0-ad77-c7791f746291
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,6 @@ dependencies:
     - field.storage.apartment.field_attachments
   module:
     - external_entities
-    - options
 id: apartment.apartment.field_attachments
 field_name: field_attachments
 entity_type: apartment
@@ -18,4 +17,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: string

--- a/conf/cmi/field.field.apartment.apartment.field_services.yml
+++ b/conf/cmi/field.field.apartment.apartment.field_services.yml
@@ -1,4 +1,4 @@
-uuid: d4c4eeb0-6cc2-4bc0-96bc-e3691615df84
+uuid: eb767fe1-f289-4d4f-b716-4de96f5530f3
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,6 @@ dependencies:
     - field.storage.apartment.field_services
   module:
     - external_entities
-    - options
 id: apartment.apartment.field_services
 field_name: field_services
 entity_type: apartment
@@ -18,4 +17,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: string

--- a/conf/cmi/field.field.apartment.apartment.field_services_url.yml
+++ b/conf/cmi/field.field.apartment.apartment.field_services_url.yml
@@ -1,4 +1,4 @@
-uuid: ddbc60d6-7a04-45f6-8376-4e48e32dc383
+uuid: ef550e29-63ea-4382-9ea4-37702148a4ba
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,6 @@ dependencies:
     - field.storage.apartment.field_services_url
   module:
     - external_entities
-    - options
 id: apartment.apartment.field_services_url
 field_name: field_services_url
 entity_type: apartment
@@ -18,4 +17,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: string

--- a/conf/cmi/field.field.project.project.field_apartments.yml
+++ b/conf/cmi/field.field.project.project.field_apartments.yml
@@ -1,4 +1,4 @@
-uuid: a56add44-495b-4ff5-b671-79c4b80f8d03
+uuid: 2e9b984e-e755-4190-956d-656a086c9b2e
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,6 @@ dependencies:
     - field.storage.project.field_apartments
   module:
     - external_entities
-    - options
 id: project.project.field_apartments
 field_name: field_apartments
 entity_type: project
@@ -18,4 +17,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: string

--- a/conf/cmi/field.field.project.project.field_attachments.yml
+++ b/conf/cmi/field.field.project.project.field_attachments.yml
@@ -1,4 +1,4 @@
-uuid: 684e58ca-5e03-49e9-bdca-968ded3b9204
+uuid: 2932dade-713a-4eab-84a0-f7f862af2523
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,6 @@ dependencies:
     - field.storage.project.field_attachments
   module:
     - external_entities
-    - options
 id: project.project.field_attachments
 field_name: field_attachments
 entity_type: project
@@ -18,4 +17,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: string

--- a/conf/cmi/field.field.project.project.field_services.yml
+++ b/conf/cmi/field.field.project.project.field_services.yml
@@ -1,4 +1,4 @@
-uuid: b7741d88-f254-4ab5-9965-5a112225484f
+uuid: 60c46162-f9a7-4c26-919a-3de9d8a2b208
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,6 @@ dependencies:
     - field.storage.project.field_services
   module:
     - external_entities
-    - options
 id: project.project.field_services
 field_name: field_services
 entity_type: project
@@ -18,4 +17,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: string

--- a/conf/cmi/field.field.project.project.field_services_url.yml
+++ b/conf/cmi/field.field.project.project.field_services_url.yml
@@ -1,4 +1,4 @@
-uuid: 2f3e4a59-33eb-4fbd-9f40-ff4a2f1f0cf0
+uuid: 6d87ff11-f81f-4f75-af9c-b1bb672f979e
 langcode: en
 status: true
 dependencies:
@@ -6,7 +6,6 @@ dependencies:
     - field.storage.project.field_services_url
   module:
     - external_entities
-    - options
 id: project.project.field_services_url
 field_name: field_services_url
 entity_type: project
@@ -18,4 +17,4 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: list_string
+field_type: string

--- a/conf/cmi/field.storage.apartment.field_attachments.yml
+++ b/conf/cmi/field.storage.apartment.field_attachments.yml
@@ -1,18 +1,18 @@
-uuid: 5e38a55d-c2fe-4330-a245-db1368325993
+uuid: 5cd7f04f-3c5d-4f96-b35c-78e75f7f315e
 langcode: en
 status: true
 dependencies:
   module:
     - external_entities
-    - options
 id: apartment.field_attachments
 field_name: field_attachments
 entity_type: apartment
-type: list_string
+type: string
 settings:
-  allowed_values: {  }
-  allowed_values_function: ''
-module: options
+  max_length: 9999
+  is_ascii: false
+  case_sensitive: false
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/conf/cmi/field.storage.apartment.field_services.yml
+++ b/conf/cmi/field.storage.apartment.field_services.yml
@@ -1,18 +1,18 @@
-uuid: 5a7fb88c-6be8-49f7-81de-70417a1edd42
+uuid: 6b32535a-9aae-4e66-8894-aab515d8b147
 langcode: en
 status: true
 dependencies:
   module:
     - external_entities
-    - options
 id: apartment.field_services
 field_name: field_services
 entity_type: apartment
-type: list_string
+type: string
 settings:
-  allowed_values: {  }
-  allowed_values_function: ''
-module: options
+  max_length: 9999
+  is_ascii: false
+  case_sensitive: false
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/conf/cmi/field.storage.apartment.field_services_url.yml
+++ b/conf/cmi/field.storage.apartment.field_services_url.yml
@@ -1,18 +1,18 @@
-uuid: 81bd7c45-d15f-4002-b8f6-d0d7ce63f309
+uuid: f607b224-6b04-4382-bc6d-f547c1935fd2
 langcode: en
 status: true
 dependencies:
   module:
     - external_entities
-    - options
 id: apartment.field_services_url
 field_name: field_services_url
 entity_type: apartment
-type: list_string
+type: string
 settings:
-  allowed_values: {  }
-  allowed_values_function: ''
-module: options
+  max_length: 9999
+  is_ascii: false
+  case_sensitive: false
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/conf/cmi/field.storage.project.field_apartments.yml
+++ b/conf/cmi/field.storage.project.field_apartments.yml
@@ -1,18 +1,18 @@
-uuid: 2b09e504-af8d-4a58-b1d7-307bfb1e9532
+uuid: 4280eb3b-e3bb-48d7-b5dd-713604dd5a5d
 langcode: en
 status: true
 dependencies:
   module:
     - external_entities
-    - options
 id: project.field_apartments
 field_name: field_apartments
 entity_type: project
-type: list_string
+type: string
 settings:
-  allowed_values: {  }
-  allowed_values_function: ''
-module: options
+  max_length: 9999
+  is_ascii: false
+  case_sensitive: false
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/conf/cmi/field.storage.project.field_attachments.yml
+++ b/conf/cmi/field.storage.project.field_attachments.yml
@@ -1,18 +1,18 @@
-uuid: a4870f5a-5e3d-460e-be36-9b9526bf7586
+uuid: 6264ee68-8695-4d79-a8bd-92fb296f7bdb
 langcode: en
 status: true
 dependencies:
   module:
     - external_entities
-    - options
 id: project.field_attachments
 field_name: field_attachments
 entity_type: project
-type: list_string
+type: string
 settings:
-  allowed_values: {  }
-  allowed_values_function: ''
-module: options
+  max_length: 9999
+  is_ascii: false
+  case_sensitive: false
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/conf/cmi/field.storage.project.field_services.yml
+++ b/conf/cmi/field.storage.project.field_services.yml
@@ -1,18 +1,18 @@
-uuid: 952777bd-c04d-4f92-9c8d-030862084e83
+uuid: 1fd78fde-17ce-43ec-9b8e-c7852b0b6530
 langcode: en
 status: true
 dependencies:
   module:
     - external_entities
-    - options
 id: project.field_services
 field_name: field_services
 entity_type: project
-type: list_string
+type: string
 settings:
-  allowed_values: {  }
-  allowed_values_function: ''
-module: options
+  max_length: 9999
+  is_ascii: false
+  case_sensitive: false
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/conf/cmi/field.storage.project.field_services_url.yml
+++ b/conf/cmi/field.storage.project.field_services_url.yml
@@ -1,18 +1,18 @@
-uuid: 1421539b-e7ff-4ed2-a026-63fe4cd51308
+uuid: 3f952128-901f-4834-876c-6c7a3c883d49
 langcode: en
 status: true
 dependencies:
   module:
     - external_entities
-    - options
 id: project.field_services_url
 field_name: field_services_url
 entity_type: project
-type: list_string
+type: string
 settings:
-  allowed_values: {  }
-  allowed_values_function: ''
-module: options
+  max_length: 9999
+  is_ascii: false
+  case_sensitive: false
+module: core
 locked: false
 cardinality: -1
 translatable: true

--- a/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
+++ b/public/themes/custom/asuntotuotanto/asuntotuotanto.theme
@@ -73,7 +73,7 @@ function asuntotuotanto_preprocess_external_entity(&$variables) {
       }
 
       if ($apartments = $entity['field_apartments']) {
-        $apartments = $apartments['#items']->getValue();
+        $apartments = isset($apartments['#items']) ? $apartments['#items']->getValue() : NULL;
         $apartments_stack = [];
 
         try {
@@ -101,7 +101,7 @@ function asuntotuotanto_preprocess_external_entity(&$variables) {
       $variables['apartments'] = $apartments_stack ?? NULL;
 
       if ($services = $entity['field_services']) {
-        $services = $services['#items']->getValue();
+        $services = isset($services['#items']) ? $services['#items']->getValue() : NULL;
         $services_stack = [];
 
         foreach ($services as $service) {
@@ -118,7 +118,7 @@ function asuntotuotanto_preprocess_external_entity(&$variables) {
       }
 
       if ($attachments = $entity['field_attachments']) {
-        $attachments = $attachments['#items']->getValue();
+        $attachments = isset($attachments['#items']) ? $attachments['#items']->getValue() : NULL;
         $attachments_stack = [];
 
         foreach ($attachments as $attachment) {
@@ -139,7 +139,7 @@ function asuntotuotanto_preprocess_external_entity(&$variables) {
       }
 
       if ($services_url = $entity['field_services_url']) {
-        $services_url = $services_url['#items']->getValue()[0]['value'];
+        $services_url = isset($services_url['#items']) ? $services_url['#items']->getValue()[0]['value'] : NULL;
         $variables['services_url'] = $services_url ?? NULL;
       }
       break;
@@ -154,7 +154,7 @@ function asuntotuotanto_preprocess_external_entity(&$variables) {
       $variables['sales_price'] = number_format($sales_price, 2, ',', '.') ?? NULL;
 
       if ($services = $entity['field_services']) {
-        $services = $services['#items']->getValue();
+        $services = isset($services['#items']) ? $services['#items']->getValue() : NULL;
         $services_stack = [];
 
         foreach ($services as $service) {
@@ -171,7 +171,7 @@ function asuntotuotanto_preprocess_external_entity(&$variables) {
       }
 
       if ($attachments = $entity['field_attachments']) {
-        $attachments = $attachments['#items']->getValue();
+        $attachments = isset($attachments['#items']) ? $attachments['#items']->getValue() : NULL;
         $attachments_stack = [];
 
         foreach ($attachments as $attachment) {
@@ -192,8 +192,8 @@ function asuntotuotanto_preprocess_external_entity(&$variables) {
       }
 
       if ($services_url = $entity['field_services_url']) {
-        $services_url = $services_url['#items']->getValue()[0]['value'];
-        $variables['services_url'] = $services_url ?? NULL;
+        $services_url = isset($services_url['#items']) ? $services_url['#items']->getValue()[0]['value'] : NULL;
+        $variables['services_url'] = $services_url;
       }
       break;
   }


### PR DESCRIPTION
Drupal rendered fatal error because our previous way of using list string for objects broke. List string were converted to plain text fields and it seems to work.